### PR TITLE
Fix record lap number display

### DIFF
--- a/src/capturecsv.cpp
+++ b/src/capturecsv.cpp
@@ -23,8 +23,8 @@ namespace ris
             sessionStarted();
             sessionEnded();
             returnToPits();
-            finishLap();
             startLap();
+            finishLap();
         }
     }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -113,9 +113,7 @@ namespace ris
     {
         Packet::Ptr lapdata = getPacket<PacketLapData>(packets_, PacketID::Lap_Data);
 
-        if (lapdata && ((lapdata->packets(PacketLapData::LapData::LAPDATA).at(static_cast<size_t>(lapdata->packets(PacketHeader::PACKETHEADER).at(0)->telemetry(PacketHeader::PLAYERCARINDEX).at(0)))->telemetry(PacketLapData::LapData::LAPDISTANCE).at(0) >= 0) &&
-                        ((lapdata->packets(PacketLapData::LapData::LAPDATA).at(static_cast<size_t>(lapdata->packets(PacketHeader::PACKETHEADER).at(0)->telemetry(PacketHeader::PLAYERCARINDEX).at(0)))->telemetry(PacketLapData::LapData::CURRENTLAPTIMEINMS).at(0) != 0) ||
-                         (lapdata->packets(PacketLapData::LapData::LAPDATA).at(static_cast<size_t>(lapdata->packets(PacketHeader::PACKETHEADER).at(0)->telemetry(PacketHeader::PLAYERCARINDEX).at(0)))->telemetry(PacketLapData::LapData::LAPDISTANCE).at(0) < 500))))
+        if (lapdata && (lapdata->packets(PacketLapData::LapData::LAPDATA).at(static_cast<size_t>(lapdata->packets(PacketHeader::PACKETHEADER).at(0)->telemetry(PacketHeader::PLAYERCARINDEX).at(0)))->telemetry(PacketLapData::LapData::CURRENTLAPTIMEINMS).at(0) != 0))
         {
             currentlap_ = lapdata->packets(PacketLapData::LapData::LAPDATA).at(static_cast<size_t>(lapdata->packets(PacketHeader::PACKETHEADER).at(0)->telemetry(PacketHeader::PLAYERCARINDEX).at(0)))->telemetry(PacketLapData::LapData::CURRENTLAPNUM).at(0);
             return true;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -138,7 +138,7 @@ namespace ris
         Packet::Ptr lapdata = getPacket<PacketLapData>(packets_, PacketID::Lap_Data);
         if (lapdata)
         {
-            if (currentlap_ != lapdata->packets(PacketLapData::LapData::LAPDATA).at(static_cast<size_t>(lapdata->packets(PacketHeader::PACKETHEADER).at(0)->telemetry(PacketHeader::PLAYERCARINDEX).at(0)))->telemetry(PacketLapData::LapData::CURRENTLAPNUM).at(0))
+            if (currentlap_ < lapdata->packets(PacketLapData::LapData::LAPDATA).at(static_cast<size_t>(lapdata->packets(PacketHeader::PACKETHEADER).at(0)->telemetry(PacketHeader::PLAYERCARINDEX).at(0)))->telemetry(PacketLapData::LapData::CURRENTLAPNUM).at(0))
             {
                 currentlap_ = lapdata->packets(PacketLapData::LapData::LAPDATA).at(static_cast<size_t>(lapdata->packets(PacketHeader::PACKETHEADER).at(0)->telemetry(PacketHeader::PLAYERCARINDEX).at(0)))->telemetry(PacketLapData::LapData::CURRENTLAPNUM).at(0);
                 return true;


### PR DESCRIPTION
After finishing a lap "Recording Lap #" would repeat, this checks the next lap is greater than instead of not equal when finishing a lap.