### PR TITLE
Prevent random values from being included in csv file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0.0)
-project(risf12021 VERSION 0.1.0)
+project(risf12021 VERSION 1.0.4)
 
 set(CMAKE_CXX_STANDARD 17)
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/src/processcartelemetry.cpp
+++ b/src/processcartelemetry.cpp
@@ -62,6 +62,14 @@ namespace ris
             {
                 PacketCarTelemetryData packet(b);
                 size_t playerindex = static_cast<size_t>(packet.packets(PacketHeader::PACKETHEADER).at(0)->telemetry(PacketHeader::PLAYERCARINDEX).at(0));
+
+                // there seems to be a glitch where I'm getting odd values
+                if ((packet.packets(PacketCarTelemetryData::CarTelemetry::CARTELEMETRY).at(playerindex)->telemetry(PacketCarTelemetryData::CarTelemetry::DRS).at(0) != 0) &&
+                    (packet.packets(PacketCarTelemetryData::CarTelemetry::CARTELEMETRY).at(playerindex)->telemetry(PacketCarTelemetryData::CarTelemetry::DRS).at(0) != 1))
+                {
+                    break;
+                }
+
                 telemetry.packets.push_back(packet.packets(PacketCarTelemetryData::CarTelemetry::CARTELEMETRY).at(playerindex));
                 telemetry.packets.push_back(packet.packets(PacketCarTelemetryData::CarTelemetryData::CARTELEMETRYDATA).at(0));
             }


### PR DESCRIPTION
Checking that the data is correct before including it into the lap telemetry.